### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Um servidor MCP (Model Context Protocol) que permite executar comandos de terminal em diferentes contextos: local, SSH e GitHub.
 
+<a href="https://glama.ai/mcp/servers/@mamprimauto/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mamprimauto/mcp/badge" alt="Global Manager MCP server" />
+</a>
+
 ## Características
 
 - **Contexto Local**: Execute comandos no sistema local


### PR DESCRIPTION
This PR adds a badge for the [Global MCP Manager](https://glama.ai/mcp/servers/@mamprimauto/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mamprimauto/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mamprimauto/mcp/badge" alt="Global Manager MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.